### PR TITLE
Send octbrowser headers with a lxml submit_form post

### DIFF
--- a/octbrowser/browser.py
+++ b/octbrowser/browser.py
@@ -185,7 +185,7 @@ class Browser(object):
         :param values: the values of the form
         :return: Response object from requests.request method
         """
-        return self.session.request(method, url, None, values)
+        return self.session.request(method, url, None, values, self._headers)
 
     def open_url(self, url, data=None, back=False, **kwargs):
         """

--- a/octbrowser/browser.py
+++ b/octbrowser/browser.py
@@ -23,10 +23,10 @@ class Browser(object):
         self._url = None
         self._back_index = False
         self._base_url = base_url
-        self._headers = {}
         self.form = None
         self.form_data = None
         self.session = session or requests.Session()
+        self.headers = self.session.headers
 
     def add_header(self, name, value):
         """
@@ -40,7 +40,7 @@ class Browser(object):
         :type value: str
         :return: None
         """
-        self._headers[name] = value
+        self.headers[name] = value
 
     def del_header(self, key):
         """
@@ -50,7 +50,10 @@ class Browser(object):
         :type key: mixed
         :return: None
         """
-        self._headers.pop(key, None)
+        try:
+            self.headers.pop(key, None)
+        except KeyError:
+            pass
 
     def set_headers(self, headers):
         """
@@ -60,7 +63,8 @@ class Browser(object):
         :type headers: dict
         :return: None
         """
-        self._headers = headers
+        self.headers.clear()
+        self.headers.update(headers)
 
     def clean_session(self):
         """
@@ -187,7 +191,7 @@ class Browser(object):
         :param values: the values of the form
         :return: Response object from requests.request method
         """
-        return self.session.request(method, url, None, values, self._headers)
+        return self.session.request(method, url, None, values)
 
     def open_url(self, url, data=None, back=False, **kwargs):
         """
@@ -201,10 +205,10 @@ class Browser(object):
         if not back:
             self._history.append(self._url)
         if data:
-            response = self.session.post(url, data, headers=self._headers, **kwargs)
+            response = self.session.post(url, data, **kwargs)
             self._url = url
         else:
-            response = self.session.get(url, headers=self._headers, **kwargs)
+            response = self.session.get(url, **kwargs)
             self._url = url
         response = self._parse_html(response)
         response.connection.close()

--- a/octbrowser/browser.py
+++ b/octbrowser/browser.py
@@ -26,7 +26,7 @@ class Browser(object):
         self.form = None
         self.form_data = None
         self.session = session or requests.Session()
-        self.headers = self.session.headers
+        self._headers = self.session.headers
 
     def add_header(self, name, value):
         """
@@ -40,7 +40,7 @@ class Browser(object):
         :type value: str
         :return: None
         """
-        self.headers[name] = value
+        self._headers[name] = value
 
     def del_header(self, key):
         """
@@ -51,7 +51,7 @@ class Browser(object):
         :return: None
         """
         try:
-            self.headers.pop(key, None)
+            self._headers.pop(key, None)
         except KeyError:
             pass
 
@@ -63,8 +63,8 @@ class Browser(object):
         :type headers: dict
         :return: None
         """
-        self.headers.clear()
-        self.headers.update(headers)
+        self._headers.clear()
+        self._headers.update(headers)
 
     def clean_session(self):
         """

--- a/octbrowser/browser.py
+++ b/octbrowser/browser.py
@@ -7,6 +7,7 @@ from octbrowser.exceptions import FormNotFoundException, NoUrlOpen, LinkNotFound
 
 
 class Browser(object):
+
     """
     This class represent a minimal browser. Build on top of lxml awesome library it let you write script for accessing
     or testing website with python scripts
@@ -14,6 +15,7 @@ class Browser(object):
     :param session: The session object to use. If set to None will use requests.Session
     :param base_url: The base url for the website, will append it for every link without a full url
     """
+
     def __init__(self, session=None, base_url=''):
         self._sess_bak = session
         self._history = []

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,20 +1,39 @@
 import unittest
 import lxml.html as lh
+from octbrowser import __version__ as ob_version
 from octbrowser.browser import Browser
 
+import threading
+import SocketServer
+try:
+    # Python 2
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+except ImportError:
+    # Python 3
+    from http.server import SimpleHTTPRequestHandler
+
+PORT = 8081
+BASE_URL = "http://localhost:{}".format(PORT)
+
+def start_http_server():
+    """
+    Run SimpleHTTPServer to serve files in test directory
+    """
+    httpd = SocketServer.TCPServer(("", PORT), SimpleHTTPRequestHandler)
+    t = threading.Thread(target=httpd.serve_forever)
+    t.setDaemon(True)
+    t.start()
+    return httpd
 
 class TestBrowserFunctions(unittest.TestCase):
 
     def setUp(self):
-        self.browser = Browser()
-
-        with open('html_test.html') as f:
-            self.html = f.read()
+        self.browser = Browser(base_url=BASE_URL)
 
     def test_form(self):
         """Test the form functions
         """
-        self.browser._html = lh.fromstring(self.html)
+        self.browser.open_url(BASE_URL + "/html_test.html")
         self.browser.get_form('.form')  # test with class selector
 
         # check input
@@ -27,6 +46,17 @@ class TestBrowserFunctions(unittest.TestCase):
 
         self.browser.get_form(None, nr=0)  # test with nr param
         self.assertEqual(self.browser.form_data['test'], 'OK')
+
+        # Check data and headers of submit_form
+        user_agent = 'python-octbrowser/{}'.format(ob_version)
+        self.browser.add_header('User-Agent', user_agent)
+        self.browser.form_data['test'] = 'octbrowser'
+        r = self.browser.submit_form()
+
+        # Verify user-agent header
+        self.assertTrue('User-Agent' in r.request.headers,
+                        'User-Agent is in post headers')
+        self.assertEqual(r.request.headers['User-Agent'], user_agent)
 
     def test_navigation(self):
         """Testing history
@@ -57,7 +87,7 @@ class TestBrowserFunctions(unittest.TestCase):
     def test_get_elements(self):
         """Testing the get_html_elements method
         """
-        self.browser._html = lh.fromstring(self.html)
+        self.browser.open_url(BASE_URL + "/html_test.html")
 
         # get the single p tag
         p = self.browser.get_html_element('#myparaf')
@@ -70,4 +100,8 @@ class TestBrowserFunctions(unittest.TestCase):
         self.assertTrue(len(tags) == 4)
 
 if __name__ == '__main__':
-    unittest.main()
+    httpd = start_http_server()
+    try:
+        unittest.main()
+    finally:
+        httpd.server_close()

--- a/tests/browser_test.py
+++ b/tests/browser_test.py
@@ -1,10 +1,14 @@
 import unittest
-import lxml.html as lh
 from octbrowser import __version__ as ob_version
 from octbrowser.browser import Browser
 
 import threading
-import SocketServer
+try:
+    # Python 2
+    import SocketServer as socketserver
+except ImportError:
+    # Python 3
+    import socketserver
 try:
     # Python 2
     from SimpleHTTPServer import SimpleHTTPRequestHandler
@@ -15,15 +19,17 @@ except ImportError:
 PORT = 8081
 BASE_URL = "http://localhost:{}".format(PORT)
 
+
 def start_http_server():
     """
     Run SimpleHTTPServer to serve files in test directory
     """
-    httpd = SocketServer.TCPServer(("", PORT), SimpleHTTPRequestHandler)
+    httpd = socketserver.TCPServer(("", PORT), SimpleHTTPRequestHandler)
     t = threading.Thread(target=httpd.serve_forever)
     t.setDaemon(True)
     t.start()
     return httpd
+
 
 class TestBrowserFunctions(unittest.TestCase):
 


### PR DESCRIPTION
I've started using `octbrowser` and I really like it. While using it I came across an issue where the `Browser._headers` are not included when using `Browser.submit_form`. I've corrected this and created a test case to verify that the bug was fixed.

I also enhanced the module's tests to use the `SimpleHTTPServer` to serve up files from the test folder. This makes it possible to more thoroughly test the browser functionality without relying on external web pages that are subject to change. I could see how this may not be a desirable change but I thought it was the simplest, reliable method of testing the aforementioned bug.

This is the first pull request I've ever submitted so if you have any feedback for me I would appreciate it.

Thank you
